### PR TITLE
Update path for types

### DIFF
--- a/packages/vite-plugin-watch-and-run/package.json
+++ b/packages/vite-plugin-watch-and-run/package.json
@@ -54,8 +54,8 @@
     "!dist/**/*.test.*",
     "!dist/**/*.spec.*"
   ],
-  "svelte": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "svelte": "./esm/index.js",
+  "types": "./esm/index.d.ts",
   "exports": {
     ".": {
       "require": "./cjs/index.js",


### PR DESCRIPTION
Changed path for typings, from the non-existent 'dist' folder to 'esm', where index.d.ts lives.